### PR TITLE
Added two false positives

### DIFF
--- a/checks/0220_misspelled_tags.php
+++ b/checks/0220_misspelled_tags.php
@@ -120,7 +120,9 @@ $false_positives = array(
 	array('trail', 'train'),
 	array('water_power', 'water_tower'),
 	array('wikimedia', 'wikipedia'),
-	array('wiki', 'wifi')
+	array('wiki', 'wifi'),
+	array('building:part', 'building:parts'),
+	array('h-frame', 'x-frame')
 );
 
 


### PR DESCRIPTION
Both building:parts=* and design=x-frame tags are documented:
http://wiki.openstreetmap.org/wiki/Proposed_features/building:parts
http://wiki.openstreetmap.org/wiki/Tag:power=tower
But KeepRight shows them as errors of type "misspelled_tags".
Please add information about this false positives to KeepRight!