### PR TITLE
Use full dates in rss export

### DIFF
--- a/web/export.php
+++ b/web/export.php
@@ -96,7 +96,7 @@ if ($_GET['format'] == 'rss') {
 		echo "\t\t\t<link>${baseURL}report_map.php?schema=" . $row['schema'] . "&amp;error=" . $row['error_id'] . "</link>\n";
 		echo "\t\t\t<guid>${baseURL}report_map.php?schema=" . $row['schema'] . "&amp;error=" . $row['error_id'] . "</guid>\n";
 
-		echo "\t\t\t<pubDate>" . date(DATE_RFC822, strtotime(get_updated_date($row['schema']))) . "</pubDate>\n";
+		echo "\t\t\t<pubDate>" . date(DATE_RFC2822, strtotime(get_updated_date($row['schema']))) . "</pubDate>\n";
 		echo "\t\t</item>\n";
 
 	}


### PR DESCRIPTION
Formating dates using DATE_RFC2822 instead of DATE_RFC822 will always produce four-digit years, as expected by feed readers and (implicitly) [the rss 2.0 spec](https://validator.w3.org/feed/docs/rss2.html#ltpubdategtSubelementOfLtitemgt).